### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Fetch relevant content from Supavec.
 
 An official implementation of an [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server for [Supavec](https://www.supavec.com).
 
+<a href="https://glama.ai/mcp/servers/nkt7wcy8ez">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/nkt7wcy8ez/badge" alt="Supavec Server MCP server" />
+</a>
+
 ## Tools
 
 -   `fetch-embeddings`: Fetch relevant embeddings and content from Supavec


### PR DESCRIPTION
This PR adds a badge for the [Supavec MCP Server](https://glama.ai/mcp/servers/nkt7wcy8ez) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/nkt7wcy8ez">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/nkt7wcy8ez/badge" alt="Supavec Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.